### PR TITLE
add nodejs runtime as it's needed by extjs gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a little layout for blog posts which can turn into slides using a-slides
 ## Set up
 
 ```bash
-sudo apt-get install bundler zlib1g-dev libxml2-dev
+sudo apt-get install bundler zlib1g-dev libxml2-dev nodejs
 bundle install
 bundle exec jekyll serve
 ```


### PR DESCRIPTION
Stepping through this on a fresh Ubuntu container there's a need for a JavaScript  runtime, and the nodejs package seems like the most simple way to get it in place
